### PR TITLE
remove common js format from the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,10 @@
   "name": "@hivemq/ui-library",
   "version": "0.3.3",
   "type": "module",
-  "main": "./dist/index.cjs.js",
   "module": "./dist/index.es.js",
   "types": "./dist/index.d.ts",
   "publishConfig": {
     "types": "./dist/index.d.ts",
-    "main": "./dist/index.cjs.js",
     "module": "./dist/index.es.js"
   },
   "engines": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { resolve } from "path";
+import { resolve } from "node:path";
 
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
@@ -30,7 +30,7 @@ export default defineConfig({
 	build: {
 		lib: {
 			entry: resolve(__dirname, "src", "lib.ts"),
-			formats: ["es", "cjs"],
+			formats: ["es"],
 			fileName: (format) => `index.${format}.js`,
 		},
 		rollupOptions: {

--- a/vite.web.config.ts
+++ b/vite.web.config.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'path'
+import { resolve } from 'node:path'
 
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'


### PR DESCRIPTION
## Why

i run into vitest issues as vite can not figure out what to import, remove this common js artifact will simplify it, [common js is deprecated](https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated) and will be removed anyway

## What

updated the vite build settings and the package.json links
