### PR TITLE
[Fix] ShellRoot grid container corrupted height

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hivemq/ui-library",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "type": "module",
   "main": "./index.ts",
   "types": "./dist/index.d.ts",
@@ -8,7 +8,9 @@
     "types": "./dist/index.d.ts",
     "module": "./dist/index.es.js"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "engines": {
     "node": ">=20",
     "pnpm": ">=9"

--- a/src/modules/Shell/ShellRoot.tsx
+++ b/src/modules/Shell/ShellRoot.tsx
@@ -97,6 +97,8 @@ export function ShellRoot({
         gridTemplateAreas={gridTemplateAreas}
         position="relative"
         background="shell.bg"
+        h={'100vh'}
+        overflow={'auto'}
       >
         {children}
 


### PR DESCRIPTION
BEFORE:
<img width="808" height="544" alt="Screenshot 2026-02-19 at 13 01 46" src="https://github.com/user-attachments/assets/9bc21d4d-d33d-4c39-97cc-60e9beaadcb3" />
AFTER: 
<img width="793" height="524" alt="Screenshot 2026-02-19 at 13 02 34" src="https://github.com/user-attachments/assets/268cc5bd-b6d2-44e1-9bd8-0a896a49a4f2" />
