### PR TITLE
[Bug] Removed canOverflowXScroll property from ContentRoot

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hivemq/ui-library",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "type": "module",
   "main": "./index.ts",
   "types": "./dist/index.d.ts",

--- a/src/modules/Content/ContentRoot.tsx
+++ b/src/modules/Content/ContentRoot.tsx
@@ -24,15 +24,9 @@ export type ContentRootProps = GridItemProps & {
 
 // TODO: apply responsive styles
 export const ContentRoot = forwardRef<HTMLDivElement, ContentRootProps>(
-  ({ children, canOverflowXScroll: overflowX, ...props }, ref) => {
+  ({ children, ...props }, ref) => {
     return (
-      <GridItem
-        ref={ref}
-        overflowX={overflowX ? 'scroll' : 'hidden'}
-        gridArea="content"
-        p={8}
-        {...props}
-      >
+      <GridItem ref={ref} gridArea="content" p={8} {...props}>
         {children}
       </GridItem>
     )

--- a/src/modules/Content/ContentRoot.tsx
+++ b/src/modules/Content/ContentRoot.tsx
@@ -19,7 +19,6 @@ import { forwardRef } from 'react'
 
 export type ContentRootProps = GridItemProps & {
   children: React.ReactNode
-  canOverflowXScroll?: boolean
 }
 
 // TODO: apply responsive styles


### PR DESCRIPTION
BEFORE:
<img width="1721" height="713" alt="Screenshot 2026-02-19 at 14 25 01" src="https://github.com/user-attachments/assets/e26d25ef-a4bc-4644-9f83-5b8d96193534" />
AFTER: 
<img width="1728" height="725" alt="Screenshot 2026-02-19 at 14 25 07" src="https://github.com/user-attachments/assets/a03de3de-eb35-4ecf-85ca-480472e3ba40" />