### PR TITLE
Fix: Make Sidebar Separators Resilient when container is scrollable

### DIFF
--- a/src/modules/Sidebar/SidebarSeparator.tsx
+++ b/src/modules/Sidebar/SidebarSeparator.tsx
@@ -23,7 +23,11 @@ export function SidebarSeparator() {
       mb={2}
       width="auto"
       height="1px"
-      // textTransform="uppercase"
+      // Defend the 1px line against flex-shrink — when the sidebar is the
+      // scroll container (`overflow-y: auto` on a flex column), default
+      // `flex-shrink: 1` collapses a 1px child to 0px and the divider
+      // visually disappears.
+      flexShrink={0}
       bg="shell.subtle"
     />
   )


### PR DESCRIPTION
## Why

- Scrollable behaviour in sidebar makes separators disappear

<!-- Describe what this change is all about -->

## What

<!-- Describe your changes -->

## Todos

<!-- Please delete options that are not relevant -->

- [ ] I have added a description to this pull request that describes the changes in detail
- [ ] I have performed a self-review of my code
- [ ] I have added a label that describes the PR type (`bug`, `enhancement`, `ci`, `refactor`, `documentation`, `test`, `chore`)
- [ ] I have added `customer-facing 🙋‍♂️` label if this PR ships customer value
- [ ] I have updated the _optional_ PR title to follow the pattern `Fix / TICKET_ID / DESCRIPTION` (e.g. `Fix / 123456 / Fixing the login button`)
- [ ] I have run manual tests to check if everything is functional
- [ ] I have added screenshots/videos that explain my graphical changes

## Screenshots
