### PR TITLE
Bump deprecated Node.js GitHub Actions to non-deprecated runtimes

### DIFF
--- a/.github/configs/pull-request-labeler-config.yml
+++ b/.github/configs/pull-request-labeler-config.yml
@@ -1,11 +1,19 @@
-# Define automatic pull request label strategy.
-# Based on the following project where you can also find additional config options.
-# 🪛 https://github.com/TimonVS/pr-labeler-action/
+# Define automatic pull request label strategy based on branch-name patterns.
+# 🪛 https://github.com/srvaroa/labeler
 
-"bug": ['fix/*']
-"documentation": ['documentation/*']
-"test": ['test/*']
-"chore": ['chore/*']
-"enhancement": ["feature/*"]
-"refactor": ["refactor/*"]
-"ci": ["ci/*"]
+version: 1
+labels:
+  - label: "bug"
+    branch: '^fix/'
+  - label: "documentation"
+    branch: '^documentation/'
+  - label: "test"
+    branch: '^test/'
+  - label: "chore"
+    branch: '^chore/'
+  - label: "enhancement"
+    branch: '^feature/'
+  - label: "refactor"
+    branch: '^refactor/'
+  - label: "ci"
+    branch: '^ci/'

--- a/.github/workflows/draft-next-release.yml
+++ b/.github/workflows/draft-next-release.yml
@@ -1,7 +1,5 @@
 # Setup release drafter to automatically generate drafts for release candidates
 # with the right labels and version
-# Release drafter version: v5.24.0 - https://github.com/release-drafter/release-drafter/commits/v5.24.0
-# Pinned action to the top commit - https://github.com/release-drafter/release-drafter/commit/65c5fb495d1e69aa8c08a3317bc44ff8aabe9772
 
 name: ✍️ Release Drafter
 
@@ -25,7 +23,7 @@ jobs:
         with:
           GH_NPM_TOKEN: ${{ secrets.GH_NPM_TOKEN }}
 
-      - uses: release-drafter/release-drafter@65c5fb495d1e69aa8c08a3317bc44ff8aabe9772
+      - uses: release-drafter/release-drafter@693d20e7c1ce1a81d3a41962f85914253b518449 # v7
         id: releaseDrafter
         with:
           config-name: configs/draft-release.yml

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -21,8 +21,11 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      # Pin to tag version 4.1.1 https://github.com/TimonVS/pr-labeler-action/commits/v4.1.1
-      - uses: TimonVS/pr-labeler-action@8b99f404a073744885d8021d1de4e40c6eaf38e2
+      - uses: actions/checkout@v4
+
+      - uses: srvaroa/labeler@bf262763a8a8e191f5847873aecc0f29df84f957 # v1.14.0
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          configuration-path: .github/configs/pull-request-labeler-config.yml
+          config_path: .github/configs/pull-request-labeler-config.yml
+          use_local_config: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Two workflow actions in this repo currently run on Node.js 16, which GitHub deprecated long ago. Node 20 itself is also being deprecated (force-flip to Node 24 on 2026-06-16, removal on 2026-09-16).

References:
- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
- Tracked in [INT-320](https://linear.app/hivemq/issue/INT-320/replace-github-actions-still-running-on-deprecated-nodejs-20)

## Changes

**`draft-next-release.yml`**: `release-drafter/release-drafter` from `65c5fb4` (v5.24.0, node16) to `693d20e7` (v7.3.1, node24).

- v6 was just a Node.js 20 upgrade.
- v7 release notes mention "JSON schema too strict with required fields" being relaxed, plus a general "new major version" marker. The config fields used here (`name-template`, `tag-template`, `categories`, `version-resolver`, `template`) are stable across v5..v7, so no `configs/draft-release.yml` change is needed.

**`label-pull-requests.yml`**: `TimonVS/pr-labeler-action` from `8b99f404` (node16) to `srvaroa/labeler@v1.14.0` (`bf262763`, docker runtime).

- Upstream `TimonVS/pr-labeler-action` is stalled at node20 (latest release v5.0.0 from 2024-02; no activity since). Bumping it would only buy a few days.
- `srvaroa/labeler` is actively maintained, runs in a docker container, and supports the same branch-name-pattern labelling we use today. It is immune to the Node deprecation entirely.

**`configs/pull-request-labeler-config.yml`**: rewritten in `srvaroa/labeler` format. Same seven branch-prefix → label mappings preserved:

```
fix/*           -> bug
documentation/* -> documentation
test/*          -> test
chore/*         -> chore
feature/*       -> enhancement
refactor/*      -> refactor
ci/*            -> ci
```

The config path is kept at `.github/configs/pull-request-labeler-config.yml` (not srvaroa's default `.github/labeler.yml`) to minimise churn.

## Notes

- All pinned SHAs are commit SHAs (not annotated tag object SHAs).
- The `Add labels` job's existing permission set (`contents: read`, `pull-requests: write`) is sufficient for srvaroa/labeler.